### PR TITLE
Change freegames to run at 11AM daily

### DIFF
--- a/src/freegames.js
+++ b/src/freegames.js
@@ -8,7 +8,7 @@ export default {
     name: "dailyFreeGames",
     once: true,
     execute(client) {
-        cron.schedule('45 23 * * *', async () => {
+        cron.schedule('0 11 * * *', async () => {
             const channel = await client.channels.fetch(CHANNEL_ID);
             if (!channel) return;
 


### PR DESCRIPTION
## Summary
- schedule `dailyFreeGames` to run every day at 11:00 AM

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fceece694832eabb7d18de9702091