### PR TITLE
Fix reboot command structure

### DIFF
--- a/src/commands/reboot.js
+++ b/src/commands/reboot.js
@@ -2,23 +2,21 @@ import { exec } from 'child_process';
 import {SlashCommandBuilder} from "@discordjs/builders";
 import {EmbedBuilder} from "discord.js";
 
-export default
-{
-    data: new SlashCommandBuilder().setName("reboot").setDescription("Reboots the server"),
-    execute: async (interaction) =>
-    {
+export default {
+    data: new SlashCommandBuilder()
+        .setName("reboot")
+        .setDescription("Reboots the server"),
+    execute: async ({ interaction }) => {
         const embed = new EmbedBuilder()
-        .setColor(0xffcc00)
-        .setTitle('🔄 Reiniciando servidor...')
-        .setDescription('O servidor será reiniciado em instantes.')
-        .setTimestamp();
+            .setColor(0xffcc00)
+            .setTitle('🔄 Reiniciando servidor...')
+            .setDescription('O servidor será reiniciado em instantes.')
+            .setTimestamp();
 
         await interaction.reply({ embeds: [embed] });
 
-        setTimeout(() =>
-        {
-            exec('sudo /sbin/reboot', (error) =>
-            {
+        setTimeout(() => {
+            exec('sudo /sbin/reboot', (error) => {
                 if (error)
                     console.error(`Erro ao reiniciar: ${error.message}`);
             });


### PR DESCRIPTION
## Summary
- update `reboot` command to use the same execute signature as the other commands

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fd31bc5e4832e9fd2cf930a81c534