### PR TITLE
Add new Codex PR command and rename Q&A command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # thrirebot
 
-## Comando `codex`
+## Comandos de IA
 
-Este bot conta com o comando `/codex` que permite enviar uma descrição ao Codex (OpenAI) para gerar novos códigos ou sugerir modificações. Para utilizar é necessário definir a variável de ambiente `OPENAI_API_KEY` com sua chave da API.
+### `/pergunta`
+
+Envia uma pergunta para a IA (ChatGPT) e retorna a resposta. Defina a variável de ambiente `OPENAI_API_KEY` para utilizar.
+
+### `/codex`
+
+Envia uma solicitação ao Codex para gerar patches de código e cria uma pull request automaticamente no repositório configurado. Para funcionar também é necessário definir `GITHUB_API_KEY` e, opcionalmente, `PR_REPO_OWNER` e `PR_REPO_NAME`.

--- a/src/commands/codex.js
+++ b/src/commands/codex.js
@@ -1,11 +1,12 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { EmbedBuilder } from 'discord.js';
 import fetch from 'node-fetch';
+import { Octokit } from 'octokit';
 
 export default {
     data: new SlashCommandBuilder()
         .setName('codex')
-        .setDescription('Envia uma solicitação ao Codex para gerar ou modificar códigos.')
+        .setDescription('Gera código e cria PRs automaticamente.')
         .addStringOption(option =>
             option
                 .setName('descricao')
@@ -26,6 +27,7 @@ export default {
                 body: JSON.stringify({
                     model: 'gpt-3.5-turbo',
                     messages: [
+                        { role: 'system', content: 'Você gera patches de código para o projeto thrirebot. Responda apenas com o diff do git.' },
                         { role: 'user', content: prompt }
                     ],
                     temperature: 0.2
@@ -38,14 +40,55 @@ export default {
             }
 
             const data = await res.json();
-            const text = data.choices?.[0]?.message?.content?.trim();
-            if (!text) {
+            const patch = data.choices?.[0]?.message?.content?.trim();
+            if (!patch) {
                 return await interaction.followUp('O Codex não retornou nenhuma resposta.');
             }
 
+            const owner = process.env.PR_REPO_OWNER || 'thrireinc';
+            const repo = process.env.PR_REPO_NAME || 'thrirebot';
+            const octokit = new Octokit({ auth: process.env.GITHUB_API_KEY });
+
+            const { data: repoData } = await octokit.request('GET /repos/{owner}/{repo}', { owner, repo });
+            const baseBranch = repoData.default_branch;
+            const { data: baseRef } = await octokit.request('GET /repos/{owner}/{repo}/git/ref/{ref}', {
+                owner,
+                repo,
+                ref: `heads/${baseBranch}`
+            });
+
+            const branchName = `codex-${Date.now()}`;
+            await octokit.request('POST /repos/{owner}/{repo}/git/refs', {
+                owner,
+                repo,
+                ref: `refs/heads/${branchName}`,
+                sha: baseRef.object.sha
+            });
+
+            const path = `codex-patches/${branchName}.patch`;
+            const commitMessage = `Codex patch: ${prompt}`;
+
+            await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+                owner,
+                repo,
+                path,
+                message: commitMessage,
+                content: Buffer.from(patch).toString('base64'),
+                branch: branchName
+            });
+
+            const prResponse = await octokit.request('POST /repos/{owner}/{repo}/pulls', {
+                owner,
+                repo,
+                title: commitMessage,
+                head: branchName,
+                base: baseBranch,
+                body: 'Patch gerado automaticamente pelo Codex.'
+            });
+
             const embed = new EmbedBuilder()
-                .setTitle('Resposta do Codex')
-                .setDescription(text.slice(0, 4096));
+                .setTitle('Pull request criada')
+                .setDescription(`[Clique aqui para ver a PR](${prResponse.data.html_url})`);
 
             await interaction.followUp({ embeds: [embed] });
         } catch (err) {

--- a/src/commands/pergunta.js
+++ b/src/commands/pergunta.js
@@ -1,0 +1,56 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { EmbedBuilder } from 'discord.js';
+import fetch from 'node-fetch';
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('pergunta')
+        .setDescription('Envie uma pergunta para a IA e receba uma resposta.')
+        .addStringOption(option =>
+            option
+                .setName('descricao')
+                .setDescription('Descrição do que deve ser gerado ou modificado.')
+                .setRequired(true)
+        ),
+    execute: async ({ interaction }) => {
+        const prompt = interaction.options.getString('descricao');
+        await interaction.deferReply();
+
+        try {
+            const res = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+                },
+                body: JSON.stringify({
+                    model: 'gpt-3.5-turbo',
+                    messages: [
+                        { role: 'user', content: prompt }
+                    ],
+                    temperature: 0.2
+                })
+            });
+
+            if (!res.ok) {
+                console.error(await res.text());
+                return await interaction.followUp('Erro ao comunicar com o Codex.');
+            }
+
+            const data = await res.json();
+            const text = data.choices?.[0]?.message?.content?.trim();
+            if (!text) {
+                return await interaction.followUp('O Codex não retornou nenhuma resposta.');
+            }
+
+            const embed = new EmbedBuilder()
+                .setTitle('Resposta da IA')
+                .setDescription(text.slice(0, 4096));
+
+            await interaction.followUp({ embeds: [embed] });
+        } catch (err) {
+            console.error(err);
+            await interaction.followUp('Erro ao processar a requisição do Codex.');
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- rename the old `/codex` command to `/pergunta` so it can be used for Q&A
- implement a new `/codex` command that requests a code patch from ChatGPT and automatically opens a pull request on GitHub
- document the new commands in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe07cf4d8832e9f9a042fdade074b