### PR TITLE
Update codex command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Envia uma pergunta para a IA (ChatGPT) e retorna a resposta. Defina a variável 
 
 ### `/codex`
 
-Envia uma solicitação ao Codex para gerar patches de código e cria uma pull request automaticamente no repositório configurado. Para funcionar também é necessário definir `GITHUB_API_KEY` e, opcionalmente, `PR_REPO_OWNER` e `PR_REPO_NAME`.
+Envia uma solicitação ao Codex para gerar código e criar uma pull request automaticamente no repositório configurado.
+Se a descrição iniciar com um nome de comando (ex.: `/ping`), um novo arquivo JavaScript será gerado em `src/commands` com a implementação retornada pela IA.
+Defina a variável `GITHUB_BOT_API_KEY` com o token do usuário **thrirebot** para que a PR seja criada por ele (caso não definido, `GITHUB_API_KEY` ainda é utilizado). Opcionalmente ajuste `PR_REPO_OWNER` e `PR_REPO_NAME`.

--- a/src/commands/codex.js
+++ b/src/commands/codex.js
@@ -17,38 +17,13 @@ export default {
         const prompt = interaction.options.getString('descricao');
         await interaction.deferReply();
 
+        const owner = process.env.PR_REPO_OWNER || 'thrireinc';
+        const repo = process.env.PR_REPO_NAME || 'thrirebot';
+        const octokit = new Octokit({ auth: process.env.GITHUB_BOT_API_KEY || process.env.GITHUB_API_KEY });
+
+        const commandMatch = prompt.match(/^\/(\w+)/);
+
         try {
-            const res = await fetch('https://api.openai.com/v1/chat/completions', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
-                },
-                body: JSON.stringify({
-                    model: 'gpt-3.5-turbo',
-                    messages: [
-                        { role: 'system', content: 'Você gera patches de código para o projeto thrirebot. Responda apenas com o diff do git.' },
-                        { role: 'user', content: prompt }
-                    ],
-                    temperature: 0.2
-                })
-            });
-
-            if (!res.ok) {
-                console.error(await res.text());
-                return await interaction.followUp('Erro ao comunicar com o Codex.');
-            }
-
-            const data = await res.json();
-            const patch = data.choices?.[0]?.message?.content?.trim();
-            if (!patch) {
-                return await interaction.followUp('O Codex não retornou nenhuma resposta.');
-            }
-
-            const owner = process.env.PR_REPO_OWNER || 'thrireinc';
-            const repo = process.env.PR_REPO_NAME || 'thrirebot';
-            const octokit = new Octokit({ auth: process.env.GITHUB_API_KEY });
-
             const { data: repoData } = await octokit.request('GET /repos/{owner}/{repo}', { owner, repo });
             const baseBranch = repoData.default_branch;
             const { data: baseRef } = await octokit.request('GET /repos/{owner}/{repo}/git/ref/{ref}', {
@@ -65,17 +40,97 @@ export default {
                 sha: baseRef.object.sha
             });
 
-            const path = `codex-patches/${branchName}.patch`;
-            const commitMessage = `Codex patch: ${prompt}`;
+            let commitMessage;
+            let prBody;
 
-            await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
-                owner,
-                repo,
-                path,
-                message: commitMessage,
-                content: Buffer.from(patch).toString('base64'),
-                branch: branchName
-            });
+            if (commandMatch) {
+                const commandName = commandMatch[1];
+                const openAiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+                    },
+                    body: JSON.stringify({
+                        model: 'gpt-3.5-turbo',
+                        messages: [
+                            { role: 'system', content: 'Você gera código em JavaScript para comandos do thrirebot. Responda apenas com o conteúdo do arquivo.' },
+                            { role: 'user', content: prompt }
+                        ],
+                        temperature: 0.2
+                    })
+                });
+
+                if (!openAiRes.ok) {
+                    console.error(await openAiRes.text());
+                    return await interaction.followUp('Erro ao comunicar com o Codex.');
+                }
+
+                const codeData = await openAiRes.json();
+                let fileContent = codeData.choices?.[0]?.message?.content || '';
+                if (!fileContent) {
+                    return await interaction.followUp('O Codex não retornou nenhuma resposta.');
+                }
+
+                fileContent = fileContent.replace(/```[\s\S]*?```/g, match => match.replace(/```(?:javascript)?\n?|```/g, '')).trim();
+
+                const filePath = `src/commands/${commandName}.js`;
+                commitMessage = `Codex comando: ${commandName}`;
+                prBody = 'Comando gerado automaticamente pelo Codex.';
+
+                await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+                    owner,
+                    repo,
+                    path: filePath,
+                    message: commitMessage,
+                    content: Buffer.from(fileContent).toString('base64'),
+                    branch: branchName,
+                    committer: { name: 'thrirebot', email: 'bot@thrire.com' },
+                    author: { name: 'thrirebot', email: 'bot@thrire.com' }
+                });
+            } else {
+                const res = await fetch('https://api.openai.com/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+                    },
+                    body: JSON.stringify({
+                        model: 'gpt-3.5-turbo',
+                        messages: [
+                            { role: 'system', content: 'Você gera patches de código para o projeto thrirebot. Responda apenas com o diff do git.' },
+                            { role: 'user', content: prompt }
+                        ],
+                        temperature: 0.2
+                    })
+                });
+
+                if (!res.ok) {
+                    console.error(await res.text());
+                    return await interaction.followUp('Erro ao comunicar com o Codex.');
+                }
+
+                const data = await res.json();
+                const patch = data.choices?.[0]?.message?.content?.trim();
+                if (!patch) {
+                    return await interaction.followUp('O Codex não retornou nenhuma resposta.');
+                }
+
+                const path = `codex-patches/${branchName}.patch`;
+                commitMessage = `Codex patch: ${prompt}`;
+                prBody = 'Patch gerado automaticamente pelo Codex.';
+
+                await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+                    owner,
+                    repo,
+                    path,
+                    message: commitMessage,
+                    content: Buffer.from(patch).toString('base64'),
+                    branch: branchName,
+                    committer: { name: 'thrirebot', email: 'bot@thrire.com' },
+                    author: { name: 'thrirebot', email: 'bot@thrire.com' }
+                });
+            }
 
             const prResponse = await octokit.request('POST /repos/{owner}/{repo}/pulls', {
                 owner,
@@ -83,7 +138,7 @@ export default {
                 title: commitMessage,
                 head: branchName,
                 base: baseBranch,
-                body: 'Patch gerado automaticamente pelo Codex.'
+                body: prBody
             });
 
             const embed = new EmbedBuilder()


### PR DESCRIPTION
## Summary
- allow Codex to create a command file when the description starts with a slash
- create PRs using a bot token so thrirebot authors the PR
- document new behaviour and env vars

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_683fe5aed06c832eba91c1c120c5f0e9