### PR TITLE
Fix stop command and prevent auto disconnect

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -9,7 +9,7 @@ client.commands = new Collection();
 client.player = new Player(client,
 {
     ytdlOptions: {quality: "highestaudio", highWaterMark: 1 << 25},
-    leaveOnEnd: true,
+    leaveOnEnd: false,
     leaveOnEndCooldown: 10000
 });
 async function setupPlayer()

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -8,7 +8,11 @@ export default
     execute: async ({client, interaction}) =>
     {
         const queue = await client.player.queues.get(interaction.guild.id);
-        if (!queue) return;
+        if (!queue)
+        {
+            await interaction.reply({ content: 'Nenhuma música tocando.', ephemeral: true });
+            return;
+        }
 
         queue.clear();
         queue.node.stop();


### PR DESCRIPTION
## Summary
- player no longer leaves the voice channel automatically
- handle `/stop` when no song is playing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6997ac8832e921dd0cd266b1ed0